### PR TITLE
This fix corrects spelling mistake

### DIFF
--- a/_includes/promo.html
+++ b/_includes/promo.html
@@ -3,7 +3,7 @@
     <div class="container text-center">
         <h2 class="title">Keylime</h2>
         <img src="assets/images/keylime.png" alt="keylime-logo" class="center">
-        <p class="intro">Opensource TPM software for Bootstrapping and Maintaining Trust</p>
+        <p class="intro">Open source TPM software for Bootstrapping and Maintaining Trust</p>
         <div class="btns">
             <a class="btn btn-cta-primary" href="https://github.com/keylime/" target="_blank">Github</a>
             <a class="btn btn-cta-primary" href="https://keylime-docs.readthedocs.io/en/latest/" target="_blank">Docs</a>


### PR DESCRIPTION
In promo.html Open source was spelled incorrectly

Resolves: #19