### PR TITLE
New readthedocs location for keylime

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@ This repository holds the Keylime website, [keylime.dev](https://keylime.dev/),
 as well as various assets.
 
 For more information about Keylime, you may also [read the
-docs](https://keylime-docs.readthedocs.io/en/latest/) or [browse the
+docs](https://keylime.readthedocs.io/en/latest/) or [browse the
 code](https://github.com/keylime/keylime).

--- a/_includes/docs.html
+++ b/_includes/docs.html
@@ -50,7 +50,7 @@ Using config file /etc/keylime.conf
            <h3 class="sub-title text-center">Try out run-time attestation..</h3>
            <div class="block">
                <p class="text-center">
-                   <a class="btn btn-cta-primary" href="https://keylime-docs.readthedocs.io/en/latest/user_guide/runtime_ima.html" target="_blank">Run-time setup</a>
+                   <a class="btn btn-cta-primary" href="https://keylime.readthedocs.io/en/latest/user_guide/runtime_ima.html" target="_blank">Run-time setup</a>
                </p>
            </div><!--//block-->
     </div><!--//container-->

--- a/_includes/promo.html
+++ b/_includes/promo.html
@@ -6,7 +6,7 @@
         <p class="intro">Bootstrap & Maintain Trust on the Edge / Cloud and IoT</p>
         <div class="btns">
             <a class="btn btn-cta-primary" href="https://github.com/keylime/" target="_blank">Github</a>
-            <a class="btn btn-cta-primary" href="https://keylime-docs.readthedocs.io/en/latest/" target="_blank">Docs</a>
+            <a class="btn btn-cta-primary" href="https://keylime.readthedocs.io/en/latest/" target="_blank">Docs</a>
             <p></p>
         </div>
         <ul class="meta list-inline">


### PR DESCRIPTION
After the move from the keylime-docs repo into the docs/ dir of the main repo, we need to update readthedocs to point to the new docs which will also follow the version tags.