### PR TITLE
Fix typo on front page.

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -26,7 +26,7 @@
                  </div>
                  <div class="content">
                      <h3 class="sub-title">Open Source</h3>
-                     <p>Keylime is all open source.. You're free to make changes and we encourage community contributions.</p>
+                     <p>Keylime is all open source. You're free to make changes and we encourage community contributions.</p>
                  </div><!--//content-->
              </div><!--//item-->
              <div class="item col-md-4 col-sm-6 col-xs-12">

--- a/_includes/docs.html
+++ b/_includes/docs.html
@@ -3,7 +3,7 @@
     <div class="container">
         <div class="docs-inner">
         <h2 class="title text-center">Want to try Keylime?</h2>
-        <h3 class="sub-title text-center">Check if your device as a TPM 2.0 (on Kernel 5.6+)</h3>
+        <h3 class="sub-title text-center">Check if your device has a TPM 2.0 (on Kernel 5.6+)</h3>
         <div class="code-block">
                 <!--//Use Prismjs - http://prismjs.com/index.html#basic-usage -->
                 <pre><code class="language-markup">
@@ -16,7 +16,7 @@ $ cat /sys/class/tpm/tpm*/tpm_version_major
                 <a class="btn btn-cta-primary" href="https://keylime.readthedocs.io/en/latest/user_guide/runtime_ima.html" target="_blank">Installation instructions</a>
             </p>
         </div><!--//block-->
-           <h3 class="sub-title text-center">Try out run-time attestation..</h3>
+           <h3 class="sub-title text-center">Try out run-time attestation</h3>
            <div class="block">
                <p class="text-center">
                    <a class="btn btn-cta-primary" href="https://keylime.readthedocs.io/en/latest/user_guide/runtime_ima.html" target="_blank">Run-time setup</a>


### PR DESCRIPTION
"Check if your device as [sic] a TPM 2.0 (on Kernel 5.6+)"

the ".." after "Try out run-time attestation" and "Keylime is all open source" are inconsistent too, so remove them.